### PR TITLE
Add Twisted version for CentOS 6.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     zip_safe=False,
 
     install_requires=[
-        'Twisted',
+        'Twisted==12.0.0',
         #'TwistedSNMP', Not currently installable via PyPI.
         #'pysnmp-se', Not currently installable via PyPI.
         ],

--- a/snmposter/scripts.py
+++ b/snmposter/scripts.py
@@ -13,18 +13,35 @@
 # limitations under the License.
 
 import sys
+import subprocess
+
 from optparse import OptionParser
 from snmposter import SNMPosterFactory
 
 
 def launcher():
+    """Launch it."""
     parser = OptionParser()
-    parser.add_option('-f', '--file', dest='filename',
-            default='agents.csv',
-            help='snmposter configuration file')
+    parser.add_option(
+        '-f',
+        '--file',
+        dest='filename',
+        default='agents.csv',
+        help='snmposter configuration file'
+    )
     options, args = parser.parse_args()
 
     factory = SNMPosterFactory()
+
+    snmpd_status = subprocess.Popen(
+        ["service", "snmpd", "status"],
+        stdout=subprocess.PIPE
+    ).communicate()[0]
+
+    if "is running" in snmpd_status:
+        message = "snmd service is running. Please stop it and try again."
+        print >> sys.stderr, message
+        sys.exit(1)
 
     try:
         factory.configure(options.filename)


### PR DESCRIPTION
By default CentOS 6 uses Python 2.6 . Twisted==12.0.0 is the last version which works on Python 2.6 .
Snmposter, TwistedSNMP and PySNMP-SE are good with Twisted==12.0.0.

We are not able to run snmposter is snmpd service is up. Check it's status before running.